### PR TITLE
Support for GNOME shell version 3.6.

### DIFF
--- a/extend-left-box@linuxdeepin.com/metadata.json
+++ b/extend-left-box@linuxdeepin.com/metadata.json
@@ -2,6 +2,6 @@
     "uuid": "extend-left-box@linuxdeepin.com",
     "name": "Extend left box",
     "description": "Extend _leftBox of gnome-shell top panel",
-    "shell-version": [ "3.4" ],
+    "shell-version": [ "3.4", "3.6" ],
     "url": "http://github.com/StephenPCG/extend-left-box"
 }


### PR DESCRIPTION
As [pointed out by @Der-Schubi](https://github.com/StephenPCG/extend-left-box/pull/2#commitcomment-2073340), [extend-left-box already works with GNOME 3.6](https://github.com/StephenPCG/extend-left-box/pull/2#commitcomment-2073340). The metadata.json should be updated to allow installation under this version, too.
