### PR TITLE
Update metadata with current GNOME versions

### DIFF
--- a/extend-left-box@linuxdeepin.com/metadata.json
+++ b/extend-left-box@linuxdeepin.com/metadata.json
@@ -2,6 +2,6 @@
     "uuid": "extend-left-box@linuxdeepin.com",
     "name": "Extend left box",
     "description": "Extend _leftBox of gnome-shell top panel",
-    "shell-version": [ "3.4", "3.6", "3.8" , "3.10", "3.12" ],
+    "shell-version": [ "3.4", "3.6", "3.8" , "3.10", "3.12", "3.14", "3.16", "3.18" ],
     "url": "http://github.com/StephenPCG/extend-left-box"
 }


### PR DESCRIPTION
I've been using this extension since 3.8, and still am in 3.18 without any issues. It should be fine to bump compatibility.

Also, I'd be willing to be the maintainer in extensions.gnome.org if @StephenPCG can't/doesn't have the interest anymore.
